### PR TITLE
FastText Model Compression

### DIFF
--- a/analyzer/.gitignore
+++ b/analyzer/.gitignore
@@ -24,3 +24,4 @@ exp/
 # Model files
 *.bin
 *.vec
+*.ftz

--- a/analyzer/Dockerfile
+++ b/analyzer/Dockerfile
@@ -20,7 +20,7 @@ RUN POETRY_VIRTUALENVS_CREATE=false poetry install --no-dev --no-interaction --n
 
 RUN mkdir -p /opt/kp/{models,analyzer}
 
-COPY models/ads.category.100.bin /opt/kp/models/
+COPY models/ads.category.100.ftz /opt/kp/models/
 COPY analyzer /opt/kp/analyzer/
 
 CMD ["gunicorn", "--workers", "2", "--bind", "0.0.0.0:5000", "analyzer.wsgi:app"]

--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -16,7 +16,7 @@ transform: fetch
 train: transform
 	python -m analyzer.wv.train
 	python -m analyzer.category.transform
-	python -m analyzer.category.train
+	python -m analyzer.category.train --compress
 
 clean:
 	rm $(RAW_DATA)/*

--- a/analyzer/analyzer/category/model.py
+++ b/analyzer/analyzer/category/model.py
@@ -14,7 +14,7 @@ class AdCategoryClassifier:
         self.confidence_threshold = confidence_threshold
         self._label_tag = "__label__"
 
-        model_path = paths.fasttext_model_file("category", dim=dim, extension="bin")
+        model_path = paths.fasttext_model_file("category", dim=dim, extension="ftz")
         self._model = fasttext.load_model(model_path)
 
         logger.info("Ad category classifier model loaded")

--- a/analyzer/analyzer/category/train.py
+++ b/analyzer/analyzer/category/train.py
@@ -3,6 +3,7 @@ import multiprocessing as mp
 
 import click
 import fasttext
+from fasttext.FastText import _FastText as FastTextModel
 
 from .. import paths
 
@@ -13,6 +14,25 @@ EMBEDDING_DIM = 100
 WORD_NGRAMS = 2
 EPOCHS = 30
 LEARNING_RATE = 0.1
+
+
+def _save_model(model: FastTextModel, extension: str = "bin") -> None:
+    dim = model.get_dimension()
+    model_file = paths.fasttext_model_file(
+        module="category", dim=dim, extension=extension
+    )
+    model.save_model(model_file)
+    logger.info(f"Ads category classification model saved to '{model_file}'")
+
+
+def _test_model(model: FastTextModel) -> None:
+    [test_samples, precision, recall] = model.test(paths.FASTTEXT_CATEGORY_TEST_PATH)
+
+    print()
+
+    logger.info(f"Model tested on {test_samples} samples")
+    logger.info(f"Precision@1 = {precision:.4f}")
+    logger.info(f"Recall@1 = {recall:.4f}")
 
 
 @click.command()
@@ -51,7 +71,14 @@ LEARNING_RATE = 0.1
     help="Number of threads used in training. Defaults to number of cores.",
     show_default=True,
 )
-def train(dim: int, word_ngrams: int, epochs: int, lr: float, threads: int) -> None:
+@click.option(
+    "--compress",
+    is_flag=True,
+    help="Compress trained model in .ftz format suitable for serving.",
+)
+def train(
+    dim: int, word_ngrams: int, epochs: int, lr: float, threads: int, compress: bool
+) -> None:
     pretrained_vectors_path = paths.fasttext_model_file(
         module="wv", dim=dim, extension="vec"
     )
@@ -74,19 +101,16 @@ def train(dim: int, word_ngrams: int, epochs: int, lr: float, threads: int) -> N
 
     print()
 
-    [test_samples, precision, recall] = model.test(paths.FASTTEXT_CATEGORY_TEST_PATH)
+    _test_model(model)
+    _save_model(model)
 
-    print()
+    if compress:
+        logger.info("Compressing trained model")
 
-    logger.info(f"Tested on {test_samples} samples")
-    logger.info(f"Precision@1 = {precision:.4f}")
-    logger.info(f"Recall@1    = {recall:.4f}")
+        model.quantize(input=None)
 
-    dim = model.get_dimension()
-    model_file = paths.fasttext_model_file(module="category", dim=dim, extension="bin")
-    model.save_model(model_file)
-
-    logger.info(f"Ads category classification model saved to '{model_file}'")
+        _test_model(model)
+        _save_model(model, extension="ftz")
 
 
 if __name__ == "__main__":

--- a/analyzer/analyzer/utils.py
+++ b/analyzer/analyzer/utils.py
@@ -1,10 +1,10 @@
 import re
 
 import numpy as np
-from fasttext.FastText import _FastText as FastText
+from fasttext.FastText import _FastText as FastTextModel
 
 
-def convert_bin_to_vec(model: FastText) -> np.ndarray:
+def convert_bin_to_vec(model: FastTextModel) -> np.ndarray:
     """Convert binary fastText model to word vectors model."""
     word_vectors = np.zeros((len(model.words), model.get_dimension() + 1), dtype=object)
 
@@ -16,7 +16,7 @@ def convert_bin_to_vec(model: FastText) -> np.ndarray:
     return word_vectors
 
 
-def save_vec_model(model: FastText, path: str) -> None:
+def save_vec_model(model: FastTextModel, path: str) -> None:
     """Save vector fastText model.
 
     Binary fastText model is covnerted to vecotr model and saved to PATH.vec


### PR DESCRIPTION
This PR closes #23.

The original category classifier models were about 1GB. After compression, their size is about 100MB.